### PR TITLE
Fix build with clang compiler

### DIFF
--- a/src/internal/provider-by-default-constructor.h
+++ b/src/internal/provider-by-default-constructor.h
@@ -77,14 +77,14 @@ public:
 	/**
 	 * @return empty set of object - this provider does not require another object to instantiate
 	 */
-	virtual types required_types() const { return types{}; }
+	virtual types required_types() const override { return types{}; }
 
 	/**
 	 * @return true
 	 *
 	 * Objects created by injector will have its dependencies resolved.
 	 */
-	virtual bool require_resolving() const;
+	virtual bool require_resolving() const override;
 
 	/**
 	 * @return constructor object passed in constructor


### PR DESCRIPTION
FreeBSD clang version 4.0.0 (tags/RELEASE_400/final 297347) (based on LLVM 4.0.0)
Target: x86_64-unknown-freebsd12.0

Build error:
--- src/CMakeFiles/injeqt.dir/internal/provider-by-default-constructor.cpp.o ---
In file included from /usr/local/ports/devel/injeqt/work/injeqt-1.2.0/src/internal/provider-by-default-constructor.cpp:21:
/usr/local/ports/devel/injeqt/work/injeqt-1.2.0/src/internal/provider-by-default-constructor.h:80:16: error: 'required_types' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
        virtual types required_types() const { return types{}; }
                      ^
/usr/local/ports/devel/injeqt/work/injeqt-1.2.0/src/internal/provider.h:83:16: note: overridden virtual function is here
        virtual types required_types() const = 0;
                      ^
In file included from /usr/local/ports/devel/injeqt/work/injeqt-1.2.0/src/internal/provider-by-default-constructor.cpp:21:
/usr/local/ports/devel/injeqt/work/injeqt-1.2.0/src/internal/provider-by-default-constructor.h:87:15: error: 'require_resolving' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
        virtual bool require_resolving() const;
                     ^
/usr/local/ports/devel/injeqt/work/injeqt-1.2.0/src/internal/provider.h:88:15: note: overridden virtual function is here
        virtual bool require_resolving() const = 0;