### PR TITLE
Disable gathering coverage data for non-GNU compilers

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,10 @@ find_package (Qt5Test 5.2 REQUIRED)
 
 option (DISABLE_COVERAGE "Do not gather coverage data" OFF)
 
+if (NOT CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+	set (DISABLE_COVERAGE ON)
+endif (NOT CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+
 include_directories (
 	${CMAKE_SOURCE_DIR}/src
 )


### PR DESCRIPTION
LLVM seems to have it's own coverage gathering that's not compatible
with GNU gcc (no libgconv implementation).

Build error:
[ 46%] Linking CXX executable get-all-with-type-role-test
cd /usr/local/ports/devel/injeqt/work/injeqt-1.2.0/test && /usr/local/bin/cmake -E cmake_link_script CMakeFiles/get-all-with-type-role-test.dir/link.txt --verbose=1
/usr/local/libexec/ccache/c++  -O2 -pipe -march=native -fstack-protector -fno-strict-aliasing -std=c++11 -Werror -W -Wall -Wextra -Wundef -Wunused -Wuninitialized -Wcast-align -Wpointer-arith -Woverloaded-virtual -Wnon-virtual-dtor -fno-common -fvisibility=hidden -fvisibility-inlines-hidden -g -fprofile-arcs -ftest-coverage -O0 -O2 -pipe -march=native -fstack-protector -fno-strict-aliasing   -fstack-protector -fprofile-arcs -ftest-coverage -O0 CMakeFiles/get-all-with-type-role-test.dir/integration/get-all-with-type-role-test.cpp.o CMakeFiles/get-all-with-type-role-test.dir/get-all-with-type-role-test_autogen/moc_compilation.cpp.o  -o get-all-with-type-role-test -Wl,-rpath,/usr/local/lib/qt5:/usr/local/ports/devel/injeqt/work/injeqt-1.2.0/src /usr/local/lib/qt5/libQt5Test.so.5.7.1 -lgcov ../src/libinjeqt.so.1.2 /usr/local/lib/qt5/libQt5Core.so.5.7.1 
/usr/bin/ld: cannot find -lgcov
c++: error: linker command failed with exit code 1 (use -v to see invocation)
