### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 dist: trusty
 language: cpp
+arch:
+  - amd64
+  - ppc64le
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install qtbase5-dev-tools qtbase5-dev libqt5core5a cmake


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/injeqt/builds/190335957 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!